### PR TITLE
Fix typo in protocol.rs

### DIFF
--- a/nxt/src/protocol.rs
+++ b/nxt/src/protocol.rs
@@ -110,7 +110,7 @@ pub enum DeviceError {
     #[error("no more files")]
     NoMoreFiles = 0x83,
     #[error("end of file expected")]
-    EofExpected0x84,
+    EofExpected = 0x84,
     #[error("end of file")]
     Eof = 0x85,
     #[error("not a linear file")]


### PR DESCRIPTION
Just found this typo while reading through the source code.